### PR TITLE
Fix warning on M1 mac bootstrap for matter

### DIFF
--- a/pw_doctor/py/pw_doctor/doctor.py
+++ b/pw_doctor/py/pw_doctor/doctor.py
@@ -143,14 +143,6 @@ def pw_plugins(ctx: DoctorContext):
 
 def unames_are_equivalent(uname_actual: str, uname_expected: str) -> bool:
     """Determine if uname values are equivalent for this tool's purposes."""
-
-    # Support `mac-arm64` through Rosetta until `mac-arm64` binaries are ready
-    # Expected and actual unames will not literally match on M1 Macs because
-    # they pretend to be Intel Macs for the purpose of environment setup. But
-    # that's intentional and doesn't require any user action.
-    if "Darwin" in uname_expected and "arm64" in uname_expected:
-        uname_expected = uname_expected.replace("arm64", "x86_64")
-
     return uname_actual == uname_expected
 
 


### PR DESCRIPTION
This seems to be old unnecessary logic now. I keep getting a warning saying I might need to redo bootstrap but the values are equivalent.

If I print the values after replacement I can see it's setting it to the incorrect value, as an artifact of when this was rosetta supported:

20230210 09:40:53 WRN 22.3.0 Darwin Kernel Version 22.3.0: Thu Jan  5 20:48:54 PST 2023; root:xnu-8792.81.2~2/RELEASE_ARM64_T6000 arm64

20230210 09:40:53 WRN 22.3.0 Darwin Kernel Version 22.3.0: Thu Jan  5 20:48:54 PST 2023; root:xnu-8792.81.2~2/RELEASE_ARM64_T6000 x86_64