### PR TITLE
Patch protobuf CVE-2022-1941

### DIFF
--- a/pw_env_setup/py/pw_env_setup/virtualenv_setup/constraint.list
+++ b/pw_env_setup/py/pw_env_setup/virtualenv_setup/constraint.list
@@ -45,7 +45,7 @@ pexpect==4.8.0
 platformdirs==3.0.0
 pickleshare==0.7.5
 prompt-toolkit==3.0.36
-protobuf==3.20.1
+protobuf==3.20.2
 ptpython==3.0.22
 ptyprocess==0.7.0
 pyasn1==0.4.8


### PR DESCRIPTION
The protobuf version in the virtual environment has this CVE:

https://nvd.nist.gov/vuln/detail/CVE-2022-1941

Update to the patched version.