### PR TITLE
Adding googletest_handler_adapter to CMakeLists.txt

### DIFF
--- a/pw_unit_test/CMakeLists.txt
+++ b/pw_unit_test/CMakeLists.txt
@@ -63,6 +63,17 @@ pw_add_library(pw_unit_test.light STATIC
     public_overrides
 )
 
+pw_add_library(pw_unit_test.googletest_handler_adapter STATIC
+  SOURCES
+    googletest_handler_adapter.cc
+  PUBLIC_DEPS
+    pw_unit_test.event_handler
+    pw_third_party.googletest
+  PUBLIC_INCLUDES
+    public
+    
+)
+
 pw_add_library(pw_unit_test.googletest STATIC
   SOURCES
     googletest_public_overrides/pw_unit_test/framework_backend.h

--- a/pw_unit_test/CMakeLists.txt
+++ b/pw_unit_test/CMakeLists.txt
@@ -71,7 +71,6 @@ pw_add_library(pw_unit_test.googletest_handler_adapter STATIC
     pw_third_party.googletest
   PUBLIC_INCLUDES
     public
-    
 )
 
 pw_add_library(pw_unit_test.googletest STATIC


### PR DESCRIPTION
googletest_handler_adapter was missing in CMake which prevents usage of googletest_handler_adapter with google test when CMake build system is being used.